### PR TITLE
Update to 20.04; add a few deps, add ensurepip back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER Matt Godbolt <matt@godbolt.org>
 
 # Enable source repositories so we can use `apt build-dep` to get all the
@@ -8,11 +8,11 @@ RUN sed -i -- 's/#deb-src/deb-src/g' /etc/apt/sources.list && \
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update -y -q && apt upgrade -y -q && apt update -y -q && \
-    # Use python3.6 build-deps for Ubuntu 18.04.
-    apt -q build-dep -y python3.6 && \
+    apt -q build-dep -y python3.8 && \
     apt -q install -y \
     curl \
     git \
+    libssl-dev \
     unzip \
     xz-utils \
     && \

--- a/build/build.sh
+++ b/build/build.sh
@@ -17,7 +17,6 @@ curl -sL https://www.python.org/ftp/python/${VERSION}/Python-${VERSION}.tgz | ta
 pushd Python-${VERSION}
 ./configure \
     --prefix=${PREFIX_DIR} \
-    --without-ensurepip \
     --without-pymalloc
 
 make -j$(nproc)


### PR DESCRIPTION
_seems_ to let us use the pip command ok. See compiler-explorer/infra#791